### PR TITLE
Respect `zIndex` property on decoration items

### DIFF
--- a/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -362,6 +362,8 @@
             decorationViewFrame.size.width -= decorationItem.contentInsets.leading + decorationItem.contentInsets.trailing;
             decorationViewFrame.size.height -= decorationItem.contentInsets.top + decorationItem.contentInsets.bottom;
 
+            decorationViewAttributes.zIndex = decorationItem.zIndex;
+
             decorationViewAttributes.frame = decorationViewFrame;
             [cachedItemAttributes addObject:decorationViewAttributes];
         }


### PR DESCRIPTION
Hi 👋 

I had some decoration items that were on top of (some of) my cells. Not ideal, but, fortunately we can set a `zIndex` on decorations. It wasn't working though, but here's a fix!