### PR TITLE
Fix incorrect insets for sections

### DIFF
--- a/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -294,11 +294,11 @@
             decorationViewFrame.origin = sectionOrigin;
 
             if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
-                decorationViewFrame.size.width += CGRectGetWidth(contentFrame) + layoutSection.contentInsets.leading;
-                decorationViewFrame.size.height = CGRectGetMaxY(contentFrame) - sectionOrigin.y + layoutSection.contentInsets.top;
+                decorationViewFrame.size.width += CGRectGetWidth(contentFrame);
+                decorationViewFrame.size.height = CGRectGetMaxY(contentFrame) - sectionOrigin.y + layoutSection.contentInsets.bottom;
             }
             if (self.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
-                decorationViewFrame.size.width = CGRectGetMaxX(contentFrame) - sectionOrigin.x;
+                decorationViewFrame.size.width = CGRectGetMaxX(contentFrame) - sectionOrigin.x + layoutSection.contentInsets.trailing;
                 decorationViewFrame.size.height += CGRectGetHeight(contentFrame);
             }
 


### PR DESCRIPTION
🐛 I think the code mostly explains it, but it was using `top`/`leading` to add to the "end" of the size when calculating frames for decorations.

This is definitely an easy one to miss! In most of the code samples (from Apple, etc), the insets are the same on all edges, but I have to use different insets for `top`/`bottom` (and `leading`/`trailing`) for the layout I'm building, and this patch lays it out correctly 🙌 