### PR TITLE
Refer collection view size instead of content size in decoration views

### DIFF
--- a/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -286,20 +286,18 @@
             }
         }
 
-        NSArray<IBPNSCollectionLayoutDecorationItem *> *decorationItems = layoutSection.decorationItems;
-        for (IBPNSCollectionLayoutDecorationItem *decorationItem in decorationItems) {
+        for (IBPNSCollectionLayoutDecorationItem *decorationItem in layoutSection.decorationItems) {
             UICollectionViewLayoutAttributes *decorationViewAttributes = [UICollectionViewLayoutAttributes layoutAttributesForDecorationViewOfKind:decorationItem.elementKind withIndexPath:[NSIndexPath indexPathForItem:0 inSection:sectionIndex]];
 
             CGRect decorationViewFrame = CGRectZero;
             decorationViewFrame.origin = sectionOrigin;
+            decorationViewFrame.size = collectionContainer.effectiveContentSize;
 
             if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
-                decorationViewFrame.size.width += CGRectGetWidth(contentFrame);
                 decorationViewFrame.size.height = CGRectGetMaxY(contentFrame) - sectionOrigin.y + layoutSection.contentInsets.bottom;
             }
             if (self.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
-                decorationViewFrame.size.width = CGRectGetMaxX(contentFrame) - sectionOrigin.x + layoutSection.contentInsets.trailing;
-                decorationViewFrame.size.height += CGRectGetHeight(contentFrame);
+                decorationViewFrame.size.width = CGRectGetMaxX(contentFrame) - sectionOrigin.x;
             }
 
             decorationViewFrame.origin.x += decorationItem.contentInsets.leading;


### PR DESCRIPTION
Refer collection view size instead of content size in decoration views.

```swift
let section = NSCollectionLayoutSection(group: group)
section.interGroupSpacing = 5
section.contentInsets = NSDirectionalEdgeInsets(top: 40, leading: 40, bottom: 40, trailing: 40)

let sectionBackgroundDecoration = NSCollectionLayoutDecorationItem.background(
    elementKind: SectionDecorationViewController.sectionBackgroundDecorationElementKind)
sectionBackgroundDecoration.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 5, bottom: 5, trailing: 10)
section.decorationItems = [sectionBackgroundDecoration]
```

The above code should be rendered as the following;

|IBPCollectionViewCompositionalLayout|UIKit|
|:-:|:-:|
|![Simulator Screen Shot - iPhone Xs - 2019-08-21 at 00 02 57](https://user-images.githubusercontent.com/40610/63359072-11607680-c3a7-11e9-9724-86eec8e37a8e.png)|![Simulator Screen Shot - iPhone Xs - 2019-08-21 at 00 02 58](https://user-images.githubusercontent.com/40610/63359079-14f3fd80-c3a7-11e9-8d71-0041c41f6886.png)|


Another example:

```swift
let section = NSCollectionLayoutSection(group: group)
section.interGroupSpacing = 5
section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 5, trailing: 0)

let sectionBackgroundDecoration = NSCollectionLayoutDecorationItem.background(
    elementKind: SectionDecorationViewController.sectionBackgroundDecorationElementKind)
sectionBackgroundDecoration.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 5, bottom: 5, trailing: 10)
section.decorationItems = [sectionBackgroundDecoration]
```

|IBPCollectionViewCompositionalLayout|UIKit|
|:-:|:-:|
|![Simulator Screen Shot - iPhone Xs - 2019-08-21 at 00 07 07](https://user-images.githubusercontent.com/40610/63359430-b54a2200-c3a7-11e9-925c-951a78bb9497.png)|![Simulator Screen Shot - iPhone Xs - 2019-08-21 at 00 07 09](https://user-images.githubusercontent.com/40610/63359431-b54a2200-c3a7-11e9-9040-1b8f77b99cce.png)|





