### PR TITLE
Fix supplementary content insets

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPNSCollectionLayoutBoundarySupplementaryItem.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPNSCollectionLayoutBoundarySupplementaryItem.m
@@ -84,7 +84,8 @@
           pinToVisibleBounds:(BOOL)pinToVisibleBounds {
     self = [super initWithSize:size
                  contentInsets:contentInsets
-                   elementKind:elementKind containerAnchor:containerAnchor
+                   elementKind:elementKind
+               containerAnchor:containerAnchor
                     itemAnchor:itemAnchor
                         zIndex:zIndex];
     if (self) {

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPNSCollectionLayoutSection.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPNSCollectionLayoutSection.m
@@ -17,6 +17,7 @@
     if (self) {
         self.group = group;
         self.orthogonalScrollingBehavior = IBPUICollectionLayoutSectionOrthogonalScrollingBehaviorNone;
+        self.supplementariesFollowContentInsets = YES;
     }
     return self;
 }

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -304,16 +304,38 @@
 
         CGSize extendedBoundary = CGSizeZero;
         for (IBPNSCollectionLayoutBoundarySupplementaryItem *boundaryItem in layoutSection.boundarySupplementaryItems) {
-            CGRect containerFrame = solver.layoutFrame;
+            CGRect containerFrame = CGRectZero;
+            containerFrame.size = collectionContainer.contentSize;
+
+            IBPNSDirectionalEdgeInsets boundaryInsets = boundaryItem.contentInsets;
+            if (layoutSection.supplementariesFollowContentInsets) {
+                boundaryInsets.top += layoutSection.contentInsets.top;
+                boundaryInsets.bottom += layoutSection.contentInsets.bottom;
+                boundaryInsets.leading += layoutSection.contentInsets.leading;
+                boundaryInsets.trailing += layoutSection.contentInsets.trailing;
+            }
+
             if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
                 containerFrame.origin.y = contentFrame.origin.y;
                 containerFrame.size.height = contentFrame.size.height;
+
+                boundaryInsets.top = 0;
+                boundaryInsets.bottom = 0;
             }
             if (self.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
                 containerFrame.origin.x = contentFrame.origin.x;
                 containerFrame.origin.y = contentFrame.origin.y;
                 containerFrame.size.width = contentFrame.size.width;
+
+                boundaryInsets.leading = 0;
+                boundaryInsets.trailing = 0;
             }
+
+            containerFrame = UIEdgeInsetsInsetRect(containerFrame,
+                                                   UIEdgeInsetsMake(boundaryInsets.top,
+                                                                    boundaryInsets.leading,
+                                                                    boundaryInsets.bottom,
+                                                                    boundaryInsets.trailing));
 
             UICollectionViewLayoutAttributes *layoutAttributes = [self prepareLayoutForBoundaryItem:boundaryItem
                                                                                      containerFrame:containerFrame


### PR DESCRIPTION
~(Cherry-picked #80 so the example builds)~ rebased! 💅 

Fixes #79.

Boundary supplementary items have two contributing `contentInsets`:

1. via its own insets
1. via its containing section (but only if `supplementariesFollowContentInsets` is enabled).

This PR does a few things towards that:

1. defaults `supplementariesFollowContentInsets` to `true`
1. starts boundary item frame relative to section frame (not the inset frame via `solver`)
1. adds boundary item insets
1. adds section insets, if `supplementariesFollowContentInsets` enabled
1. calculates available frame with above insets

To illustrate this, we can set some large leading insets to highlight this:

```swift
section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 50, bottom: 0, trailing: 10)
sectionHeader.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 100, bottom: 0, trailing: 10)
sectionFooter.contentInsets = .zero
```

And then toggling: `supplementariesFollowContentInsets` gives:

|  | iOS 12.4 (before) | iOS 12.4 (after) | iOS 13 |
| --- | --- | --- | --- |
| `true` | <img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63567902-34666400-c528-11e9-8f4c-0a95e667ff55.png"> | <img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63567989-83ac9480-c528-11e9-94e9-28738327a1d2.png"> | <img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63567875-1ef13a00-c528-11e9-9a69-e2826c2a01fa.png"> |
| `false` | <img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63567932-4ba55180-c528-11e9-9500-930075efd74e.png"> | <img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63567973-742d4b80-c528-11e9-96ae-f8e2346c28eb.png"> | <img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63567950-595ad700-c528-11e9-9043-14cf3e69839e.png"> |