### PR TITLE
Supplementary items adding to decoration size

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -268,32 +268,6 @@
             }
         }
 
-        for (IBPNSCollectionLayoutDecorationItem *decorationItem in layoutSection.decorationItems) {
-            UICollectionViewLayoutAttributes *layoutAttributes = [UICollectionViewLayoutAttributes layoutAttributesForDecorationViewOfKind:decorationItem.elementKind withIndexPath:[NSIndexPath indexPathForItem:0 inSection:sectionIndex]];
-
-            CGRect frame = CGRectZero;
-            frame.origin = sectionOrigin;
-            frame.size = collectionContainer.effectiveContentSize;
-
-            if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
-                frame.size.height = CGRectGetMaxY(contentFrame) - sectionOrigin.y + layoutSection.contentInsets.bottom;
-            }
-            if (self.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
-                frame.size.width = CGRectGetMaxX(contentFrame) - sectionOrigin.x;
-            }
-
-            frame.origin.x += decorationItem.contentInsets.leading;
-            frame.origin.y += decorationItem.contentInsets.top;
-            frame.size.width -= decorationItem.contentInsets.leading + decorationItem.contentInsets.trailing;
-            frame.size.height -= decorationItem.contentInsets.top + decorationItem.contentInsets.bottom;
-
-            layoutAttributes.zIndex = decorationItem.zIndex;
-
-            layoutAttributes.frame = frame;
-            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:sectionIndex];
-            cachedDecorationAttributes[indexPath] = layoutAttributes;
-        }
-
         CGRect insetsContentFrame = contentFrame;
         if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
             insetsContentFrame.origin.y += layoutSection.contentInsets.bottom + self.configuration.interSectionSpacing;
@@ -390,6 +364,32 @@
                 self.hasPinnedSupplementaryItems = YES;
                 [layoutAttributesForPinnedSupplementaryItems addObject:layoutAttributes];
             }
+        }
+
+        for (IBPNSCollectionLayoutDecorationItem *decorationItem in layoutSection.decorationItems) {
+            UICollectionViewLayoutAttributes *layoutAttributes = [UICollectionViewLayoutAttributes layoutAttributesForDecorationViewOfKind:decorationItem.elementKind withIndexPath:[NSIndexPath indexPathForItem:0 inSection:sectionIndex]];
+
+            CGRect frame = CGRectZero;
+            frame.origin = sectionOrigin;
+            frame.size = collectionContainer.effectiveContentSize;
+
+            if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
+                frame.size.height = CGRectGetMaxY(contentFrame) - sectionOrigin.y + layoutSection.contentInsets.bottom;
+            }
+            if (self.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
+                frame.size.width = CGRectGetMaxX(contentFrame) - sectionOrigin.x;
+            }
+
+            frame.origin.x += decorationItem.contentInsets.leading;
+            frame.origin.y += decorationItem.contentInsets.top;
+            frame.size.width -= decorationItem.contentInsets.leading + decorationItem.contentInsets.trailing;
+            frame.size.height -= decorationItem.contentInsets.top + decorationItem.contentInsets.bottom;
+
+            layoutAttributes.zIndex = decorationItem.zIndex;
+
+            layoutAttributes.frame = frame;
+            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:sectionIndex];
+            cachedDecorationAttributes[indexPath] = layoutAttributes;
         }
     }
 }


### PR DESCRIPTION
~(Cherry-picked #80 so the example builds)~ rebased! 💅 

Fixes #77.

This is a pretty easy one - moving the `decorationItems` processing down, means the `contentFrame` is updated while processing `boundarySupplementaryItems`, so it fills the whole area.

I used a more exaggerated example here than in #77 with bigger `leading` insets, so we can now render with full height, but also insetting correctly:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63568724-1cdcaa80-c52b-11e9-9069-51302d8f601c.png">