### PR TITLE
Fractional sizes to use container's full size, without insets

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPNSCollectionLayoutSize.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPNSCollectionLayoutSize.m
@@ -48,10 +48,10 @@
     IBPNSCollectionLayoutDimension *heightDimension = self.heightDimension;
 
     if (widthDimension.isFractionalWidth) {
-        effectiveSize.width = contentSize.width * widthDimension.dimension;
+        effectiveSize.width = container.contentSize.width * widthDimension.dimension;
     }
     if (widthDimension.isFractionalHeight) {
-        effectiveSize.width = contentSize.height * widthDimension.dimension;
+        effectiveSize.width = container.contentSize.height * widthDimension.dimension;
     }
     if (widthDimension.isAbsolute) {
         effectiveSize.width = widthDimension.dimension;
@@ -64,10 +64,10 @@
     }
 
     if (heightDimension.isFractionalWidth) {
-        effectiveSize.height = contentSize.width * heightDimension.dimension;
+        effectiveSize.height = container.contentSize.width * heightDimension.dimension;
     }
     if (heightDimension.isFractionalHeight) {
-        effectiveSize.height = contentSize.height * heightDimension.dimension;
+        effectiveSize.height = container.contentSize.height * heightDimension.dimension;
     }
     if (heightDimension.isAbsolute) {
         effectiveSize.height = heightDimension.dimension;


### PR DESCRIPTION
Part of #78.

Relative sizes should be relative to the full container, not the inset container.

It's _possible_ this will introduce some regression somewhere else. I'm not sure if this should check `ignoringInsets` - but I _think_ it's correct behaviour to always ignore insets.

Before:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63569125-e3a53a00-c52c-11e9-8f75-5f74f87ca0ae.png">

After:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63569147-020b3580-c52d-11e9-924f-937b6705b5a7.png">

iOS 13 reference:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63569133-e99b1b00-c52c-11e9-858b-8c41e13790d0.png">
