### PR TITLE
Trailing section inset on orthogonal views

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -230,10 +230,10 @@
             } else {
                 CGRect frame = cellFrame;
                 if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
-                    frame.size.height += layoutItem.contentInsets.bottom;
+                    frame.size.height += layoutItem.contentInsets.bottom + layoutSection.contentInsets.bottom;
                 }
                 if (self.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
-                    frame.size.width += layoutItem.contentInsets.trailing;
+                    frame.size.width += layoutItem.contentInsets.trailing + layoutSection.contentInsets.trailing;
                 }
                 contentFrame = CGRectUnion(contentFrame, frame);
             }


### PR DESCRIPTION
~(Cherry-picked #80 so the example builds)~ rebased! 💅 

Part of #78.

Adds the section insets to the end of an orthogonal view in the direction it scrolls.

I didn't spend time checking why the vertical insets aren't applied - I don't think it's the same thing as here, but it's related.

Before:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63570194-2832d480-c531-11e9-9180-fc4e64c30879.png">

After:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63570268-66c88f00-c531-11e9-8697-040a8a0b090c.png">


iOS 13 reference:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/33126/63570224-439ddf80-c531-11e9-89be-9e1fe4230c0a.png">
