### PR TITLE
Fix orthogonal sections with decoration items

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -487,6 +487,15 @@
                                                                                                                      configuration:configuration];
     collectionViewLayout.parent = self;
     collectionViewLayout.containerSection = section;
+    
+    NSDictionary *decorationClassDict = @{};
+    @try {
+        decorationClassDict = [[self valueForKey:@"_decorationViewClassDict"] copy];
+    } @catch (NSException *exception) {}
+    for (NSString *reuseIdentifier in decorationClassDict) {
+        Class cellClass = decorationClassDict[reuseIdentifier];
+        [collectionViewLayout registerClass:cellClass forDecorationViewOfKind:reuseIdentifier];
+    }
 
     IBPCollectionViewOrthogonalScrollerEmbeddedScrollView *scrollView = [[IBPCollectionViewOrthogonalScrollerEmbeddedScrollView alloc] initWithFrame:CGRectZero
                                                                                                                                 collectionViewLayout:collectionViewLayout];

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -456,6 +456,7 @@
     IBPNSCollectionLayoutSection *orthogonalSection = section.copy;
     orthogonalSection.contentInsets = IBPNSDirectionalEdgeInsetsZero;
     orthogonalSection.boundarySupplementaryItems = @[];
+    orthogonalSection.decorationItems = @[];
     orthogonalSection.orthogonalScrollingBehavior = IBPUICollectionLayoutSectionOrthogonalScrollingBehaviorNone;
 
     IBPNSCollectionLayoutSize *orthogonalGroupSize = section.group.layoutSize;
@@ -487,15 +488,6 @@
                                                                                                                      configuration:configuration];
     collectionViewLayout.parent = self;
     collectionViewLayout.containerSection = section;
-    
-    NSDictionary *decorationClassDict = @{};
-    @try {
-        decorationClassDict = [[self valueForKey:@"_decorationViewClassDict"] copy];
-    } @catch (NSException *exception) {}
-    for (NSString *reuseIdentifier in decorationClassDict) {
-        Class cellClass = decorationClassDict[reuseIdentifier];
-        [collectionViewLayout registerClass:cellClass forDecorationViewOfKind:reuseIdentifier];
-    }
 
     IBPCollectionViewOrthogonalScrollerEmbeddedScrollView *scrollView = [[IBPCollectionViewOrthogonalScrollerEmbeddedScrollView alloc] initWithFrame:CGRectZero
                                                                                                                                 collectionViewLayout:collectionViewLayout];


### PR DESCRIPTION
Supercedes https://github.com/kishikawakatsumi/IBPCollectionViewCompositionalLayout/pull/116

Further investigation, the correct behavior of decoration items on orthogonal sections is the background view should be only drawn on the base collection view. Should not be drawn on orthogonal scroll views.


|iOS 13|iOS 12|
|:-:|:-:|
|![Simulator Screen Shot - iPhone Xs - 2019-10-01 at 23 42 42](https://user-images.githubusercontent.com/40610/65972867-711d6780-e4a5-11e9-879f-a06bb7734934.png)|![Simulator Screen Shot - iPhone Xs - 2019-10-01 at 23 42 28](https://user-images.githubusercontent.com/40610/65972868-711d6780-e4a5-11e9-8839-ee55caf1ae63.png)|
