### PR TITLE
Add support for offsets on top and bottom boundary supplementary views

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -338,7 +338,21 @@
                     layoutAttributes.frame = itemFrame;
 
                     if (boundaryItem.extendsBoundary && extendedBoundary.height < CGRectGetHeight(itemFrame)) {
-                        CGFloat extendHeight = CGRectGetHeight(itemFrame) - extendedBoundary.height;
+                        CGFloat extendHeight;
+                        
+                        extendHeight = CGRectGetHeight(itemFrame) - extendedBoundary.height - boundaryItem.offset.y;
+                        if(extendHeight < 0) {
+                            extendHeight = 0;
+                        }
+                        
+                        CGRect newFrame = itemFrame;
+                        newFrame.origin.y = sectionOrigin.y + boundaryItem.offset.y - CGRectGetHeight(itemFrame);
+                        if(newFrame.origin.y < sectionOrigin.y) {
+                            newFrame.origin.y = sectionOrigin.y;
+                        }
+                        layoutAttributes.frame = newFrame;
+                        
+                        
                         for (UICollectionViewLayoutAttributes *attributes in cachedItemAttributes.allValues) {
                             if (attributes.representedElementCategory == UICollectionElementCategoryCell ||
                                 attributes.representedElementCategory == UICollectionElementCategoryDecorationView) {

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -389,12 +389,45 @@
                 if (boundaryItem.alignment == IBPNSRectAlignmentBottom ||
                     boundaryItem.alignment == IBPNSRectAlignmentBottomLeading ||
                     boundaryItem.alignment == IBPNSRectAlignmentBottomTrailing) {
-                    CGRect frame = layoutAttributes.frame;
+                    CGRect itemFrame = layoutAttributes.frame;
                     if (!boundaryItem.extendsBoundary) {
-                        frame.origin.y -= CGRectGetHeight(frame);
+                        itemFrame.origin.y -= CGRectGetHeight(itemFrame);
                     }
-                    frame.origin.y += layoutSection.contentInsets.bottom;
-                    layoutAttributes.frame = frame;
+                    itemFrame.origin.y += layoutSection.contentInsets.bottom;
+                    layoutAttributes.frame = itemFrame;
+                    
+                    if (boundaryItem.extendsBoundary) {
+                        CGFloat extendHeight;
+                        
+                        extendHeight = CGRectGetHeight(itemFrame) + boundaryItem.offset.y;
+                        
+                        CGRect newFrame = itemFrame;
+                        newFrame.origin.y += boundaryItem.offset.y;
+                        layoutAttributes.frame = newFrame;
+                        
+                        for (UICollectionViewLayoutAttributes *attributes in cachedItemAttributes.allValues) {
+                            if (attributes.representedElementCategory == UICollectionElementCategoryCell ||
+                                attributes.representedElementCategory == UICollectionElementCategoryDecorationView) {
+                                CGRect frame = attributes.frame;
+                                if (CGRectGetMinY(frame) >= CGRectGetMinY(itemFrame)) {
+                                    frame.origin.y += extendHeight;
+                                    attributes.frame = frame;
+                                    contentFrame = CGRectUnion(contentFrame, frame);
+                                }
+                            }
+                        }
+                        for (IBPCollectionViewOrthogonalScrollerSectionController *controller in orthogonalScrollerSectionControllers.allValues) {
+                            CGRect frame = controller.scrollView.frame;
+                            if (CGRectGetMinY(frame) >= CGRectGetMinY(itemFrame)) {
+                                frame.origin.y += extendHeight;
+                                controller.scrollView.frame = frame;
+                                contentFrame = CGRectUnion(contentFrame, frame);
+                            }
+                        }
+                        extendedBoundary.height += extendHeight;
+                    }
+                    
+                    
                 }
             }
             if (self.scrollDirection == UICollectionViewScrollDirectionHorizontal) {


### PR DESCRIPTION
This add support for offsetting top and bottom boundary supplementary views.
I didn't need leading and trailing cases so I didn't try to implement them.
I might do it later if I find some time.

I'm still not 100% comfortable with the code base so if I'm sorry if I added my code in the wrong place.

I hope this will be useful 👍 

Fixes top and bottom cases for #121 