### PR TITLE
Set .clipToBounds to NO for internal orthogonal UICollectionView

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -495,6 +495,7 @@
     scrollView.directionalLockEnabled = YES;
     scrollView.showsHorizontalScrollIndicator = NO;
     scrollView.showsVerticalScrollIndicator = NO;
+	scrollView.clipsToBounds = NO;
 
     switch (section.orthogonalScrollingBehavior) {
         case IBPUICollectionLayoutSectionOrthogonalScrollingBehaviorNone:


### PR DESCRIPTION
On iOS 11.4 internal orthogonal UICollectionView clipping shadow that I've added to my cells.
I believe it is appropriate to set .clipToBounds to NO for that internal UICollectionView.
What do you think?
Here is an example screenshots that indicate clipping and expected result:
![screenshot](https://user-images.githubusercontent.com/1284116/67207784-e3d29080-f41c-11e9-8617-ec612e40bb12.png)      ![expected](https://user-images.githubusercontent.com/1284116/67207785-e3d29080-f41c-11e9-87eb-fdda5a4159fe.png)


