### PR TITLE
Fix item size calculation inside layoutGroup

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPCollectionCompositionalLayoutSolver.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPCollectionCompositionalLayoutSolver.m
@@ -148,7 +148,7 @@
                 return;
             }
 
-            itemSize.width = (CGRectGetWidth(containerFrame) - interItemFixedSpacing * (group.count - 1)) / group.count;
+            itemSize.width = (itemSize.width - interItemFixedSpacing * (group.count - 1)) / group.count;
             contentFrame.size = itemSize;
 
             for (NSInteger i = 0; i < group.count; i++) {
@@ -166,7 +166,7 @@
                 return;
             }
 
-            itemSize.height = (CGRectGetHeight(containerFrame) - interItemFixedSpacing * (group.count - 1)) / group.count;
+            itemSize.height = (itemSize.height - interItemFixedSpacing * (group.count - 1)) / group.count;
             contentFrame.size = itemSize;
 
             for (NSInteger i = 0; i < group.count; i++) {


### PR DESCRIPTION
close #125

I think itemSize should not ignore effectiveSizeForContainer.

https://github.com/kishikawakatsumi/IBPCollectionViewCompositionalLayout/blob/master/Sources/IBPCollectionViewCompositionalLayout/IBPCollectionCompositionalLayoutSolver.m#L108
```
CGSize itemSize = [item.layoutSize effectiveSizeForContainer:container];
```

At least this changes work well reproduction code https://github.com/ichiko/IBPCVCLLayoutGroupContentInsetsBug 