### PR TITLE
Disable SwiftLint in IBPCollectionViewCompositionalLayoutInteroperability.swift

### DIFF
--- a/IBPCollectionViewCompositionalLayoutInteroperability.swift
+++ b/IBPCollectionViewCompositionalLayoutInteroperability.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable all
 import IBPCollectionViewCompositionalLayout
 
 typealias NSCollectionLayoutAnchor = IBPNSCollectionLayoutAnchor


### PR DESCRIPTION
This file may be copied into projects in which SwiftLint is used. Depending on the SwiftLint configurations, there may be some lint violations. So let's disable SwiftLint at all in this file for ease of introduction.