### PR TITLE
Fixed Issue with big sections

### DIFF
--- a/IBPCollectionViewCompositionalLayout.podspec
+++ b/IBPCollectionViewCompositionalLayout.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
                             DESC
   s.homepage              = "https://github.com/kishikawakatsumi/#{s.name}"
   s.ios.deployment_target = '10.0'
+  s.tvos.deployment_target = '11.0'
   s.source_files          = 'Sources/**/*.{h,m}'
   s.public_header_files   = "Sources/#{s.name}/include/*.h"
   s.frameworks            = 'UIKit'

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPCollectionViewOrthogonalScrollerEmbeddedScrollView.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPCollectionViewOrthogonalScrollerEmbeddedScrollView.m
@@ -6,8 +6,4 @@
 
 @implementation IBPCollectionViewOrthogonalScrollerEmbeddedScrollView
 
-- (void)setFrame:(CGRect)frame {
-    [super setFrame:frame];
-}
-
 @end

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -266,11 +266,11 @@
             if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
                 scrollViewFrame.origin.y = sectionOrigin.y + layoutSection.contentInsets.top;
                 scrollViewFrame.size.width = collectionContainer.contentSize.width;
-                scrollViewFrame.size.height = MIN(solver.layoutFrame.size.height, collectionContainer.contentSize.height);
+                scrollViewFrame.size.height = solver.layoutFrame.size.height;
             }
             if (self.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
                 scrollViewFrame.origin.x = sectionOrigin.x + layoutSection.contentInsets.leading;
-                scrollViewFrame.size.width = MIN(solver.layoutFrame.size.width, collectionContainer.contentSize.width);
+                scrollViewFrame.size.width = solver.layoutFrame.size.width;
                 scrollViewFrame.size.height = collectionContainer.contentSize.height;
             }
             scrollView.frame = scrollViewFrame;
@@ -496,6 +496,16 @@
     scrollView.showsHorizontalScrollIndicator = NO;
     scrollView.showsVerticalScrollIndicator = NO;
 	scrollView.clipsToBounds = NO;
+    scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    
+    switch (configuration.scrollDirection) {
+        case UICollectionViewScrollDirectionVertical:
+            scrollView.alwaysBounceHorizontal = NO;
+            break;
+        case UICollectionViewScrollDirectionHorizontal:
+            scrollView.alwaysBounceVertical = NO;
+            break;
+    }
 
     switch (section.orthogonalScrollingBehavior) {
         case IBPUICollectionLayoutSectionOrthogonalScrollingBehaviorNone:

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -497,15 +497,6 @@
     scrollView.showsVerticalScrollIndicator = NO;
 	scrollView.clipsToBounds = NO;
     scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-    
-    switch (configuration.scrollDirection) {
-        case UICollectionViewScrollDirectionVertical:
-            scrollView.alwaysBounceHorizontal = NO;
-            break;
-        case UICollectionViewScrollDirectionHorizontal:
-            scrollView.alwaysBounceVertical = NO;
-            break;
-    }
 
     switch (section.orthogonalScrollingBehavior) {
         case IBPUICollectionLayoutSectionOrthogonalScrollingBehaviorNone:

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -668,6 +668,7 @@
 
                     [layoutAttributes addObject:attributes];
                 }];
+                [cell removeFromSuperview];
 
                 continue;
             }

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -496,7 +496,8 @@
     scrollView.showsHorizontalScrollIndicator = NO;
     scrollView.showsVerticalScrollIndicator = NO;
 	scrollView.clipsToBounds = NO;
-
+    
+#if !TARGET_OS_TV
     switch (section.orthogonalScrollingBehavior) {
         case IBPUICollectionLayoutSectionOrthogonalScrollingBehaviorNone:
         case IBPUICollectionLayoutSectionOrthogonalScrollingBehaviorContinuous:
@@ -515,6 +516,7 @@
             scrollView.decelerationRate = UIScrollViewDecelerationRateFast;
             break;
     }
+#endif
 
     return scrollView;
 }

--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -496,7 +496,6 @@
     scrollView.showsHorizontalScrollIndicator = NO;
     scrollView.showsVerticalScrollIndicator = NO;
 	scrollView.clipsToBounds = NO;
-    scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
 
     switch (section.orthogonalScrollingBehavior) {
         case IBPUICollectionLayoutSectionOrthogonalScrollingBehaviorNone:


### PR DESCRIPTION
When the section was bigger than the collectionview's bound the section was not rendered correctly.
This fixes this behaviour and will always use the dimension from the resolver to set the frame of the embedded collectionview.