### PR TITLE
Dealing with UIScrollViewContentInsetAdjustmentNever case

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -145,7 +145,7 @@
 
     UIEdgeInsets collectionContentInset = UIEdgeInsetsZero;
     if (@available(iOS 11.0, *)) {
-        if ([collectionView respondsToSelector:@selector(safeAreaInsets)]) {
+        if ([collectionView respondsToSelector:@selector(safeAreaInsets)] && collectionView.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentNever) {
             collectionContentInset = collectionView.safeAreaInsets;
         }
     }


### PR DESCRIPTION
I found CollectionView cells move unexpectedly with scrolling. This bug occurs when CollectionView's `ContentInsetAdjustment` is set to `.never`. You can check this bug in [my branch](https://github.com/tosh7/IBPCollectionViewCompositionalLayout/tree/bug/contentInsetAdjustmentBehavior).
This happens because you always set `collectionView.safeAreaInsets` to `collectionContentInset` even though CollectionView's `ContentInsetAdjustment` is `.never`.  I fixed this bug with avoiding to set `collectionContentInset`, if CollectionView's `ContentInsetAdjustment` is `never`.